### PR TITLE
#1 bugfix Error: Cannot read property 'mock' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var path = require('path');
 var MockLite = require('mockjs-lite');
 var walkdir = require('node-walkdir');
 
-var Mock = MockLite.Mock;
+var Mock = MockLite;
 var Random = MockLite.Random;
 
 var template = fs.readFileSync(path.join(__dirname, 'doc.html'), 'utf8');


### PR DESCRIPTION
系统：mac
node版本：v6.4.0
npm版本：5.3.0
问题：根据文档制作出现错误，具体如下：
```
TypeError: Cannot read property 'mock' of undefined
    at /project/node_modules/express-mockjs/index.js:94:20
    at Layer.handle [as handle_request] (/project/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/project/node_modules/express/lib/router/index.js:317:13)
    at /project/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/project/node_modules/express/lib/router/index.js:335:12)
    at next (/project/node_modules/express/lib/router/index.js:275:10)
    at expressInit (/project/node_modules/express/lib/middleware/init.js:40:5)
    at Layer.handle [as handle_request] (/project/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/project/node_modules/express/lib/router/index.js:317:13)
    at /project/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/project/node_modules/express/lib/router/index.js:335:12)
    at next (/project/node_modules/express/lib/router/index.js:275:10)
    at query (/project/node_modules/express/lib/middleware/query.js:45:5)
    at Layer.handle [as handle_request] (/project/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/project/node_modules/express/lib/router/index.js:317:13)
    at /project/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/project/node_modules/express/lib/router/index.js:335:12)
    at next (/project/node_modules/express/lib/router/index.js:275:10)
    at Function.handle (/project/node_modules/express/lib/router/index.js:174:3)
    at EventEmitter.handle (/project/node_modules/express/lib/application.js:174:10)
    at Server.app (/project/node_modules/express/lib/express.js:38:9)
    at emitTwo (events.js:106:13)
```


结果：根据mock-lite文档修复